### PR TITLE
chore(vscode): update configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
   "recommendations": [
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
-    "shinnn.stylelint"
+    "stylelint.vscode-stylelint"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,19 +1,6 @@
 {
   "editor.tabSize": 2,
   "eslint.packageManager": "yarn",
-  "eslint.autoFixOnSave": true,
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    {
-      "language": "typescript",
-      "autoFix": true
-    },
-    {
-      "language": "typescriptreact",
-      "autoFix": true
-    }
-  ],
   "editor.formatOnSave": true,
   "[javascript]": {
     "editor.formatOnSave": false
@@ -29,5 +16,8 @@
   },
   "css.validate": false,
   "less.validate": false,
-  "scss.validate": false
+  "scss.validate": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }


### PR DESCRIPTION
- The recommended `stylelint` extension is no longer in the marketplace.
- Eslint fix-on-save has changed the way it works and requires different configuration.