### PR TITLE
test: ensure fetch mocks are cleared between tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "fetch-mock": "^9.9.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.3",
+    "node-fetch": "^2.6.0",
     "prettier": "^2.0.5",
     "stylelint": "^13.4.0",
     "stylelint-config-palantir": "^5.0.0",

--- a/src/util/fetchJSON.test.ts
+++ b/src/util/fetchJSON.test.ts
@@ -1,6 +1,10 @@
 import fetchMock from 'fetch-mock'
 import fetchJSON from './fetchJSON'
 
+beforeEach(() => {
+  fetchMock.reset()
+})
+
 test('passes the URL through as-is to fetch', async () => {
   fetchMock.getOnce((url) => {
     expect(url).toEqual('/example')

--- a/yarn.lock
+++ b/yarn.lock
@@ -8242,6 +8242,11 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-forge@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"


### PR DESCRIPTION
For some reason this test started failing with `Adding route with same name or matcher as existing route.`. Fixing that meant adding the `fetchMock.reset()` call, but that revealed an issue where `node-fetch` is required by `fetch-mock` but it does not actually depend on it. So this adds `node-fetch` as a dependency.