### PR TITLE
fix: ensure election definition is treated as JSON

### DIFF
--- a/src/api/configure.ts
+++ b/src/api/configure.ts
@@ -5,6 +5,7 @@ export default async function configure(election: Election): Promise<void> {
   const response = await fetchJSON<ConfigureResponse>('/scan/configure', {
     method: 'post',
     body: JSON.stringify(election),
+    headers: { 'Content-Type': 'application/json' },
   })
 
   if (response.status !== 'ok') {


### PR DESCRIPTION
Without this, the `Content-Type` header defaults to `text/plain` which is not what we want and makes `module-scan` be configured with an empty election definition. module-scan should do some validation on the definition, but that's something to deal with separately.