### PR TITLE
test(coverage): add tests for `DashboardScreen`

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,10 +98,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "statements": 49,
-        "branches": 31,
-        "lines": 50,
-        "functions": 51
+        "statements": 55,
+        "branches": 46,
+        "lines": 55,
+        "functions": 62
       }
     }
   }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -41,7 +41,7 @@ export interface Batch {
   id: number
   count: number
   startedAt: number
-  endedAt: number
+  endedAt?: number
 }
 export interface ScanStatusResponse {
   electionHash?: string

--- a/src/screens/DashboardScreen.test.tsx
+++ b/src/screens/DashboardScreen.test.tsx
@@ -1,0 +1,105 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { ScanStatusResponse } from '../config/types'
+import DashboardScreen from './DashboardScreen'
+
+test('null state', () => {
+  const deleteBatch = jest.fn()
+  const invalidateBatch = jest.fn()
+  const status: ScanStatusResponse = {
+    batches: [],
+  }
+  const component = render(
+    <DashboardScreen
+      deleteBatch={deleteBatch}
+      invalidateBatch={invalidateBatch}
+      isScanning={false}
+      status={status}
+    />
+  )
+
+  expect(component.baseElement.textContent).toMatch(
+    /No ballots have been scanned/
+  )
+})
+
+test('shows scanned ballot count', () => {
+  const deleteBatch = jest.fn()
+  const invalidateBatch = jest.fn()
+  const status: ScanStatusResponse = {
+    batches: [
+      { id: 1, count: 1, startedAt: 0, endedAt: 0 },
+      { id: 2, count: 3, startedAt: 0, endedAt: 0 },
+    ],
+  }
+  const component = render(
+    <DashboardScreen
+      deleteBatch={deleteBatch}
+      invalidateBatch={invalidateBatch}
+      isScanning={false}
+      status={status}
+    />
+  )
+
+  expect(component.baseElement.textContent).toMatch(
+    /A total of 4 ballots have been scanned in 2 batches/
+  )
+})
+
+test('shows whether a batch is scanning', () => {
+  const deleteBatch = jest.fn()
+  const invalidateBatch = jest.fn()
+  const status: ScanStatusResponse = {
+    batches: [{ id: 1, count: 3, startedAt: 0 }],
+  }
+  const component = render(
+    <DashboardScreen
+      deleteBatch={deleteBatch}
+      invalidateBatch={invalidateBatch}
+      isScanning
+      status={status}
+    />
+  )
+
+  expect(component.baseElement.textContent).toMatch(/Scanning…/)
+})
+
+test('allows deleting a batch', async () => {
+  const deleteBatch = jest.fn()
+  const invalidateBatch = jest.fn()
+  const status: ScanStatusResponse = {
+    batches: [
+      { id: 1, count: 1, startedAt: 0, endedAt: 0 },
+      { id: 2, count: 3, startedAt: 0, endedAt: 0 },
+    ],
+  }
+  const component = render(
+    <DashboardScreen
+      deleteBatch={deleteBatch}
+      invalidateBatch={invalidateBatch}
+      isScanning={false}
+      status={status}
+    />
+  )
+
+  expect(deleteBatch).not.toHaveBeenCalled()
+  const [
+    deleteBatch1Button,
+    deleteBatch2Button,
+  ] = component.getAllByText('Delete', { selector: 'button' })
+
+  // Click delete & confirm.
+  jest.spyOn(window, 'confirm').mockReturnValueOnce(true)
+  deleteBatch1Button.click()
+  expect(deleteBatch).toHaveBeenNthCalledWith(1, status.batches[0].id)
+
+  // Click delete but cancel.
+  jest.spyOn(window, 'confirm').mockReturnValueOnce(false)
+  deleteBatch2Button.click()
+  expect(deleteBatch).not.toHaveBeenCalledWith(status.batches[1].id)
+
+  // Click delete & confirm.
+  jest.spyOn(window, 'confirm').mockReturnValueOnce(true)
+  deleteBatch2Button.click()
+  expect(deleteBatch).toHaveBeenNthCalledWith(2, status.batches[1].id)
+})

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -28,7 +28,7 @@ interface Props {
 
 const DashboardScreen = ({ isScanning, status, deleteBatch }: Props) => {
   const { batches } = status
-  const batchCount = (batches && batches.length) || 0
+  const batchCount = batches.length
   const ballotCount =
     batches && batches.reduce((result, b) => result + b.count, 0)
   return (
@@ -65,7 +65,7 @@ const DashboardScreen = ({ isScanning, status, deleteBatch }: Props) => {
                       {isScanning && !batch.endedAt ? (
                         <Scanning>Scanning…</Scanning>
                       ) : (
-                        <small>{shortDateTime(batch.endedAt)}</small>
+                        <small>{shortDateTime(batch.endedAt!)}</small>
                       )}
                     </TD>
                     <TD narrow>


### PR DESCRIPTION
- Removes defaulting of `branchCount` to 0 because it will always be present.
- Changes type of `endedAt` property to allow it to be missing since the server does not require it to be set.