### PR TITLE
fix: use zero padding for date formatting

### DIFF
--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -12,11 +12,13 @@ const Scanning = styled.em`
   color: rgb(71, 167, 75);
 `
 
+const z2 = (number: number) => number.toString().padStart(2, '0')
+
 const shortDateTime = (unixTimestamp: number) => {
   const d = new Date(unixTimestamp * 1000)
-  return `${d.getFullYear()}-${
-    d.getMonth() + 1
-  }-${d.getDate()} ${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}`
+  return `${d.getFullYear()}-${z2(d.getMonth() + 1)}-${z2(
+    d.getDate()
+  )} ${d.getHours()}:${z2(d.getMinutes())}:${z2(d.getSeconds())}`
 }
 
 interface Props {


### PR DESCRIPTION
We may want to use `Intl.DateTimeFormat` rather than this, but this fixes the current implementation for now.