### PR TITLE
bug: Allow toggle undefined for non-marked options.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,8 +44,9 @@ const App: React.FC = () => {
     adjudication: { remaining: 0, adjudicated: 0 },
   })
   const [loadingElection, setLoadingElection] = useState(false)
-  const { batches, adjudication } = status
-  const isScanning = batches && batches[0] && !batches[0].endedAt
+  const { adjudication } = status
+
+  const [isScanning, setIsScanning] = useState(false)
 
   useEffect(() => {
     getConfig().then((config) => {
@@ -60,6 +61,9 @@ const App: React.FC = () => {
       setStatus((prevStatus) => {
         if (JSON.stringify(prevStatus) === JSON.stringify(newStatus)) {
           return prevStatus
+        }
+        if (newStatus.batches[0]?.endedAt) {
+          setIsScanning(false)
         }
         return newStatus
       })
@@ -131,6 +135,7 @@ const App: React.FC = () => {
   }, [processCardData, setCardServerAvailable])
 
   const scanBatch = useCallback(async () => {
+    setIsScanning(true)
     try {
       await fetch('/scan/scanBatch', {
         method: 'post',

--- a/src/workflows/BallotReviewScreenWorkflow.ts
+++ b/src/workflows/BallotReviewScreenWorkflow.ts
@@ -103,7 +103,7 @@ export function change(
   state: Review,
   contest: Contest,
   option: ContestOption,
-  marked: MarkStatus
+  marked: MarkStatus | undefined
 ): Review {
   assert.equal(state.type, 'review')
   const { ballot, changes } = state
@@ -129,17 +129,15 @@ export function toggle(
   assert.equal(state.type, 'review')
   const { ballot, changes } = state
   const changedMark = changes[contest.id]?.[option.id]
-  const currentMark =
-    'marks' in ballot && ballot.marks?.[contest.id]?.[option.id]
-
-  return change(
-    state,
-    contest,
-    option,
+  const ballotMarks = 'marks' in ballot ? ballot.marks : undefined
+  const currentMark = ballotMarks?.[contest.id]?.[option.id]
+  const newChangedMark =
     (changedMark ?? currentMark) === MarkStatus.Marked // these parentheses matter, as it seems === otherwise takes precedence.
-      ? MarkStatus.Unmarked
+      ? currentMark === undefined
+        ? undefined
+        : MarkStatus.Unmarked
       : MarkStatus.Marked
-  )
+  return change(state, contest, option, newChangedMark)
 }
 
 export function noBallots(state: Init): NoBallots {


### PR DESCRIPTION
When a ballot was un-scannable ("smiley face") and adjudicator selected an option it would be "marked" but then upon second click it would be "unmarked" instead of toggling back to `undefined`. This allows toggling between "marked" and `undefined` for options which were initially undefined. 

If mark starts out as "marked" or "unmarked" or "marginal" then it is only possible to toggle between "marked" and "unmarked".