### PR TITLE
fix: component render should be pure function

### DIFF
--- a/src/screens/BallotReviewScreen.tsx
+++ b/src/screens/BallotReviewScreen.tsx
@@ -87,11 +87,11 @@ export default function BallotReviewScreen({
       ? undefined
       : state.ballot
 
-  if (state.type === 'no-ballots') {
-    history.push('/')
-  }
-
   useEffect(() => {
+    if (state.type === 'no-ballots') {
+      history.push('/')
+    }
+
     if (state.type === 'init') {
       ;(async () => {
         try {
@@ -109,7 +109,7 @@ export default function BallotReviewScreen({
         }
       })()
     }
-  }, [ballotId, state, setState])
+  }, [ballotId, history, state, setState])
 
   const relRect = relativeRect(
     ballot?.ballot.image.width || 1,


### PR DESCRIPTION
React was complaining that rendering `BallotReviewScreen` sometimes was causing a side effect during render. This turned out to be the redirect to the dashboard when there are no ballots to review, so I just moved that into the `useEffect` callback.