### PR TITLE
add usb controller button to load election screen

### DIFF
--- a/src/components/ElectionConfiguration.tsx
+++ b/src/components/ElectionConfiguration.tsx
@@ -7,6 +7,8 @@ import MainNav from './MainNav'
 import Screen from './Screen'
 import Text from './Text'
 
+import USBControllerButton from './USBControllerButton'
+
 export interface Props {
   acceptFiles(files: readonly File[]): void
 }
@@ -44,7 +46,9 @@ const ElectionConfiguration = ({ acceptFiles }: Props) => {
           </Prose>
         </MainChild>
       </Main>
-      <MainNav />
+      <MainNav isTestMode={false}>
+        <USBControllerButton />
+      </MainNav>
     </Screen>
   )
 }


### PR DESCRIPTION
without it, we're in a lurch trying to load the election package without having mounted the USB.