### PR TITLE
fix: enable Scan New Batch button after last scanned batch is deleted

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -71,9 +71,7 @@ const App: React.FC = () => {
         if (JSON.stringify(prevStatus) === JSON.stringify(newStatus)) {
           return prevStatus
         }
-        if (newStatus.batches[0]?.endedAt) {
-          setIsScanning(false)
-        }
+        setIsScanning(newStatus.batches.some(({ endedAt }) => !endedAt))
         return newStatus
       })
     } catch (error) {


### PR DESCRIPTION
If we delete the in-progress batch being scanned, we need to make sure the Scan New Batch button becomes enabled again. To do this, we change the logic for disabling it to be that on update it always sets `isScanning` to true if any batch has no `endedAt`.