### PR TITLE
show loading screen until config is loaded

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -36,6 +36,7 @@ import StatusFooter from './components/StatusFooter'
 const App: React.FC = () => {
   const history = useHistory()
   const [cardServerAvailable, setCardServerAvailable] = useState(true)
+  const [isConfigLoaded, setIsConfigLoaded] = useState(false)
   const [election, setElection] = useState<OptionalElection>()
   const [electionHash, setElectionHash] = useState<string>()
   // used to hide batches while they're being deleted
@@ -60,7 +61,10 @@ const App: React.FC = () => {
   }, [])
 
   useEffect(() => {
-    refreshConfig()
+    ;(async () => {
+      await refreshConfig()
+      setIsConfigLoaded(true)
+    })()
   }, [refreshConfig])
 
   const updateStatus = useCallback(async () => {
@@ -360,7 +364,18 @@ const App: React.FC = () => {
     )
   }
 
-  return <LoadElectionScreen setElection={setElection} />
+  if (isConfigLoaded) {
+    return <LoadElectionScreen setElection={setElection} />
+  }
+  return (
+    <Screen>
+      <Main>
+        <MainChild maxWidth={false}>
+          <h1>Loading Configuration...</h1>
+        </MainChild>
+      </Main>
+    </Screen>
+  )
 }
 
 export default App


### PR DESCRIPTION
`module-scan` is now set up to listen to web requests right away, even as it's loading templates. The web request will block until the config is ready to be returned. So this PR sets up the front-end to show a loading screen while this happens. This screen is only relevant when the front-end starts up faster than the backend loads the config.