### PR TITLE
fix: preserve election hash through module-scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "fast-text-encoding": "^1.0.2",
     "http-proxy-middleware": "^0.19.1",
     "js-file-download": "^0.4.6",
+    "js-sha256": "^0.9.0",
     "normalize.css": "^8.0.1",
     "pluralize": "^7.0.0",
     "react": "^16.13.1",

--- a/src/api/hmpb.ts
+++ b/src/api/hmpb.ts
@@ -1,14 +1,20 @@
-import { Election } from '@votingworks/ballot-encoder'
 import { EventEmitter } from 'events'
 import { ReviewBallot, BallotSheetInfo } from '../config/types'
-import { BallotPackage, BallotPackageEntry } from '../util/ballot-package'
+import {
+  BallotPackage,
+  BallotPackageEntry,
+  ElectionDefinition,
+} from '../util/ballot-package'
 import fetchJSON from '../util/fetchJSON'
 import { patch as patchConfig } from './config'
 
 export interface AddTemplatesEvents extends EventEmitter {
   on(
     event: 'configuring',
-    callback: (pkg: BallotPackage, election: Election) => void
+    callback: (
+      pkg: BallotPackage,
+      electionDefinition: ElectionDefinition
+    ) => void
   ): this
   on(
     event: 'uploading',
@@ -18,7 +24,10 @@ export interface AddTemplatesEvents extends EventEmitter {
   on(event: 'error', callback: (error: Error) => void): this
   off(
     event: 'configuring',
-    callback: (pkg: BallotPackage, election: Election) => void
+    callback: (
+      pkg: BallotPackage,
+      electionDefinition: ElectionDefinition
+    ) => void
   ): this
   off(
     event: 'uploading',
@@ -26,7 +35,11 @@ export interface AddTemplatesEvents extends EventEmitter {
   ): this
   off(event: 'completed', callback: (pkg: BallotPackage) => void): this
   off(event: 'error', callback: (error: Error) => void): this
-  emit(event: 'configuring', pkg: BallotPackage, election: Election): boolean
+  emit(
+    event: 'configuring',
+    pkg: BallotPackage,
+    electionDefinition: ElectionDefinition
+  ): boolean
   emit(
     event: 'uploading',
     pkg: BallotPackage,
@@ -41,8 +54,8 @@ export function addTemplates(pkg: BallotPackage): AddTemplatesEvents {
 
   setImmediate(async () => {
     try {
-      result.emit('configuring', pkg, pkg.election)
-      await patchConfig({ election: pkg.election })
+      result.emit('configuring', pkg, pkg.electionDefinition)
+      await patchConfig({ election: pkg.electionDefinition })
 
       for (const ballot of pkg.ballots) {
         result.emit('uploading', pkg, ballot)

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -10,6 +10,7 @@ import type {
   BallotPageMetadata,
   Size,
 } from '@votingworks/hmpb-interpreter'
+import { ElectionDefinition } from '../util/ballot-package'
 import type { AdjudicationInfo } from './types/ballot-review'
 
 export interface Dictionary<T> {
@@ -123,7 +124,7 @@ export interface GetConfigResponse {
 }
 
 export interface PatchConfigRequest {
-  election?: Election | null
+  election?: Election | ElectionDefinition | null
   testMode?: boolean
 }
 export type PatchConfigResponse = OkResponse

--- a/src/screens/LoadElectionScreen.tsx
+++ b/src/screens/LoadElectionScreen.tsx
@@ -53,7 +53,7 @@ const LoadElectionScreen = ({ setElection }: Props) => {
                 ballotStyle: ballot.ballotConfig.ballotStyleId,
                 precinct:
                   getPrecinctById({
-                    election: pkg.election,
+                    election: pkg.electionDefinition.election,
                     precinctId: ballot.ballotConfig.precinctId,
                   })?.name ?? ballot.ballotConfig.precinctId,
                 isLiveMode: ballot.ballotConfig.isLiveMode,
@@ -64,7 +64,7 @@ const LoadElectionScreen = ({ setElection }: Props) => {
               setCurrentUploadingBallotIndex(pkg.ballots.indexOf(ballot))
             })
             .on('completed', () => {
-              setElection(pkg.election)
+              setElection(pkg.electionDefinition.election)
             })
         })
 

--- a/src/util/ballot-package.test.ts
+++ b/src/util/ballot-package.test.ts
@@ -16,7 +16,10 @@ test('readBallotPackage finds all expected ballots', async () => {
     ],
     'ballot-package-state-of-hamilton.zip'
   )
-  const { ballots, election } = await readBallotPackage(file)
+  const {
+    ballots,
+    electionDefinition: { election },
+  } = await readBallotPackage(file)
   const ballotStyleIds = election.ballotStyles.map(({ id }) => id)
   const precinctIds = election.precincts.map(({ id }) => id)
   expect(election.title).toEqual('General Election')

--- a/yarn.lock
+++ b/yarn.lock
@@ -7623,6 +7623,11 @@ js-file-download@^0.4.6:
   resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.6.tgz#a6482d9b39a8db733c12a3de018df27d71ab5856"
   integrity sha512-Epd9nCpeWUb/lyV0O1yTdoJA/vPvcRb2rhI+01fVvNg7GC0QtBgFzwaMwz7Q46y7maBYjAS2s8VDrl5Dsm5S8w==
 
+js-sha256@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
+  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Without this, differences in how we call `JSON.stringify` end up creating different hashes.

Related to https://github.com/votingworks/module-scan/pull/174.