### PR TITLE
fix: reset test mode config after factory reset

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -107,12 +107,12 @@ const App: React.FC = () => {
   const unconfigureServer = useCallback(async () => {
     try {
       await patchConfig({ election: null })
-      setElection(undefined)
+      await refreshConfig()
       history.replace('/')
     } catch (error) {
       console.log('failed unconfigureServer()', error) // eslint-disable-line no-console
     }
-  }, [history, setElection])
+  }, [history, refreshConfig])
 
   const loadElectionFromCard = useCallback(async () => {
     const card = await fetchJSON<CardReadLongResponse>('/card/read_long')


### PR DESCRIPTION
Refreshing the config ensures we're in sync with the server.