### PR TITLE
retry loading configuration until we get it.

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -74,10 +74,16 @@ const App: React.FC = () => {
   }, [])
 
   useEffect(() => {
-    ;(async () => {
-      await refreshConfig()
-      setIsConfigLoaded(true)
-    })()
+    const initialize = async () => {
+      try {
+        await refreshConfig()
+        setIsConfigLoaded(true)
+      } catch (e) {
+        window.setTimeout(initialize, 1000)
+      }
+    }
+
+    initialize()
   }, [refreshConfig])
 
   const updateStatus = useCallback(async () => {


### PR DESCRIPTION

on production machines, things boot so quickly the backend server isn't even responding yet by the time the frontend starts. So just retry loading the config until we get it.