### PR TITLE
fix: show invalid test mode pages correctly

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -358,7 +358,12 @@ const App: React.FC = () => {
 
   if (election) {
     if (adjudication.remaining > 0 && !isScanning) {
-      return <BallotEjectScreen continueScanning={continueScanning} />
+      return (
+        <BallotEjectScreen
+          continueScanning={continueScanning}
+          isTestMode={isTestMode}
+        />
+      )
     }
 
     return (

--- a/src/screens/BallotEjectScreen.test.tsx
+++ b/src/screens/BallotEjectScreen.test.tsx
@@ -23,7 +23,7 @@ test('says the sheet is unreadable if it is', async () => {
   const continueScanning = jest.fn()
 
   const { container, getByText } = render(
-    <BallotEjectScreen continueScanning={continueScanning} />
+    <BallotEjectScreen continueScanning={continueScanning} isTestMode />
   )
 
   await act(async () => {
@@ -109,7 +109,7 @@ test('says the ballot sheet is overvoted if it is', async () => {
   const continueScanning = jest.fn()
 
   const { container, getByText } = render(
-    <BallotEjectScreen continueScanning={continueScanning} />
+    <BallotEjectScreen continueScanning={continueScanning} isTestMode />
   )
 
   await act(async () => {
@@ -188,7 +188,7 @@ test('says the ballot sheet is blank if it is', async () => {
   const continueScanning = jest.fn()
 
   const { container, getByText } = render(
-    <BallotEjectScreen continueScanning={continueScanning} />
+    <BallotEjectScreen continueScanning={continueScanning} isTestMode />
   )
 
   await act(async () => {
@@ -206,4 +206,108 @@ test('says the ballot sheet is blank if it is', async () => {
   fireEvent.click(getByText('Tabulate Duplicate Ballot'))
   fireEvent.click(getByText('Tabulate Ballot and Continue Scanning'))
   expect(continueScanning).toHaveBeenCalledWith(true)
+})
+
+test('calls out live ballot sheets in test mode', async () => {
+  const response: BallotSheetInfo = {
+    id: 'mock-sheet-id',
+    front: {
+      image: { url: '/front/url' },
+      interpretation: {
+        type: 'InvalidTestModePage',
+        metadata: {
+          ballotStyleId: '1',
+          precinctId: '1',
+          ballotType: BallotType.Standard,
+          electionHash: '',
+          isTestMode: false,
+          locales: { primary: 'en-US' },
+          pageNumber: 1,
+        },
+      },
+    },
+    back: {
+      image: { url: '/back/url' },
+      interpretation: {
+        type: 'InvalidTestModePage',
+        metadata: {
+          ballotStyleId: '1',
+          precinctId: '1',
+          ballotType: BallotType.Standard,
+          electionHash: '',
+          isTestMode: false,
+          locales: { primary: 'en-US' },
+          pageNumber: 2,
+        },
+      },
+    },
+  }
+  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+
+  const continueScanning = jest.fn()
+
+  const { container, getByText } = render(
+    <BallotEjectScreen continueScanning={continueScanning} isTestMode />
+  )
+
+  await act(async () => {
+    await waitFor(() => fetchMock.called)
+  })
+
+  expect(container).toMatchSnapshot()
+
+  fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
+  expect(continueScanning).toHaveBeenCalledWith()
+})
+
+test('calls out test ballot sheets in live mode', async () => {
+  const response: BallotSheetInfo = {
+    id: 'mock-sheet-id',
+    front: {
+      image: { url: '/front/url' },
+      interpretation: {
+        type: 'InvalidTestModePage',
+        metadata: {
+          ballotStyleId: '1',
+          precinctId: '1',
+          ballotType: BallotType.Standard,
+          electionHash: '',
+          isTestMode: false,
+          locales: { primary: 'en-US' },
+          pageNumber: 1,
+        },
+      },
+    },
+    back: {
+      image: { url: '/back/url' },
+      interpretation: {
+        type: 'InvalidTestModePage',
+        metadata: {
+          ballotStyleId: '1',
+          precinctId: '1',
+          ballotType: BallotType.Standard,
+          electionHash: '',
+          isTestMode: false,
+          locales: { primary: 'en-US' },
+          pageNumber: 2,
+        },
+      },
+    },
+  }
+  fetchMock.getOnce('/scan/hmpb/review/next-sheet', response)
+
+  const continueScanning = jest.fn()
+
+  const { container, getByText } = render(
+    <BallotEjectScreen continueScanning={continueScanning} isTestMode={false} />
+  )
+
+  await act(async () => {
+    await waitFor(() => fetchMock.called)
+  })
+
+  expect(container).toMatchSnapshot()
+
+  fireEvent.click(getByText('Confirm Ballot Removed and Continue Scanning'))
+  expect(continueScanning).toHaveBeenCalledWith()
 })

--- a/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
+++ b/src/screens/__snapshots__/BallotEjectScreen.test.tsx.snap
@@ -1,5 +1,187 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`calls out live ballot sheets in test mode 1`] = `
+<div>
+  <div
+    class="sc-VigVT djCdRx"
+  >
+    <div
+      class="sc-bZQynM cWyHmc"
+    >
+      <div
+        class="sc-gzVnrw iMtlFY"
+      >
+        <div
+          class="sc-htoDjs fdtLZY"
+        >
+          <div
+            class="sc-dnqmqq kKbVPv"
+          >
+            Voting
+            <span>
+              Works
+            </span>
+          </div>
+          <div
+            class="sc-iwsKbI jQhHGA"
+          >
+            Ballot Scanner
+          </div>
+        </div>
+        <div
+          class="sc-gZMcBi idZcZf"
+        >
+          <button
+            class="sc-ifAKCX khGLgj"
+            type="button"
+          >
+            Confirm Ballot Removed and Continue Scanning
+          </button>
+        </div>
+      </div>
+    </div>
+    <main
+      class="sc-bdVaJa kYuSve"
+    >
+      <div
+        class="sc-bwzfXH hLOwzs"
+      >
+        <div
+          class="sc-fjdhpX eRpYQP"
+        >
+          <div
+            class="sc-htpNat eawaaV"
+          >
+            <div
+              class="sc-jTzLTM gSIlWD"
+            >
+              Live Ballot
+            </div>
+            <p>
+              This last scanned sheet 
+              <strong>
+                was not tabulated
+              </strong>
+              .
+            </p>
+            <p>
+              Remove the LIVE ballot before continuing.
+            </p>
+          </div>
+          <div
+            class="sc-jzJRlG ggDwyK"
+          >
+            <div>
+              <img
+                alt="front"
+                src="/front/url"
+              />
+            </div>
+            <div>
+              <img
+                alt="back"
+                src="/back/url"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
+exports[`calls out test ballot sheets in live mode 1`] = `
+<div>
+  <div
+    class="sc-VigVT djCdRx"
+  >
+    <div
+      class="sc-bZQynM cWyHmc"
+    >
+      <div
+        class="sc-gzVnrw iMtlFY"
+      >
+        <div
+          class="sc-htoDjs fdtLZY"
+        >
+          <div
+            class="sc-dnqmqq kKbVPv"
+          >
+            Voting
+            <span>
+              Works
+            </span>
+          </div>
+          <div
+            class="sc-iwsKbI jQhHGA"
+          >
+            Ballot Scanner
+          </div>
+        </div>
+        <div
+          class="sc-gZMcBi idZcZf"
+        >
+          <button
+            class="sc-ifAKCX khGLgj"
+            type="button"
+          >
+            Confirm Ballot Removed and Continue Scanning
+          </button>
+        </div>
+      </div>
+    </div>
+    <main
+      class="sc-bdVaJa kYuSve"
+    >
+      <div
+        class="sc-bwzfXH hLOwzs"
+      >
+        <div
+          class="sc-fjdhpX eRpYQP"
+        >
+          <div
+            class="sc-htpNat eawaaV"
+          >
+            <div
+              class="sc-jTzLTM gSIlWD"
+            >
+              Test Ballot
+            </div>
+            <p>
+              This last scanned sheet 
+              <strong>
+                was not tabulated
+              </strong>
+              .
+            </p>
+            <p>
+              Remove the TEST ballot before continuing.
+            </p>
+          </div>
+          <div
+            class="sc-jzJRlG ggDwyK"
+          >
+            <div>
+              <img
+                alt="front"
+                src="/front/url"
+              />
+            </div>
+            <div>
+              <img
+                alt="back"
+                src="/back/url"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+`;
+
 exports[`says the ballot sheet is blank if it is 1`] = `
 <div>
   <div


### PR DESCRIPTION
If a live ballot is scanned in test mode or vice versa, show a specific error message for that case. Showing "unreadable" is right, but confusing.