### PR TITLE
fix: improve test mode toggling

### DIFF
--- a/src/AppRoot.tsx
+++ b/src/AppRoot.tsx
@@ -54,7 +54,7 @@ const App: React.FC = () => {
     []
   )
   const [isTestMode, setTestMode] = useState(false)
-  const [togglingTestMode, setTogglingTestMode] = useState(false)
+  const [isTogglingTestMode, setTogglingTestMode] = useState(false)
   const [status, setStatus] = useState<ScanStatusResponse>({
     batches: [],
     adjudication: { remaining: 0, adjudicated: 0 },
@@ -223,16 +223,13 @@ const App: React.FC = () => {
   }, [])
 
   const toggleTestMode = useCallback(async () => {
-    // eslint-disable-next-line no-restricted-globals, no-alert
-    if (confirm('Toggling test mode will zero out your scans. Are you sure?')) {
-      try {
-        setTogglingTestMode(true)
-        await patchConfig({ testMode: !isTestMode })
-        await refreshConfig()
-        history.replace('/')
-      } finally {
-        setTogglingTestMode(false)
-      }
+    try {
+      setTogglingTestMode(true)
+      await patchConfig({ testMode: !isTestMode })
+      await refreshConfig()
+      history.replace('/')
+    } finally {
+      setTogglingTestMode(false)
     }
   }, [history, isTestMode, refreshConfig])
 
@@ -377,7 +374,7 @@ const App: React.FC = () => {
               hasBatches={!!status.batches.length}
               isTestMode={isTestMode}
               toggleTestMode={toggleTestMode}
-              togglingTestMode={togglingTestMode}
+              isTogglingTestMode={isTogglingTestMode}
             />
           </Route>
           <Route path="/">

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -61,42 +61,44 @@ const StyledButton = styled('button').attrs((props: Attrs) => ({
 export interface Props extends StyledButtonProps {
   component?: StyledComponent<'button', never, StyledButtonProps, never>
   onPress: MouseEventHandler
+  ref?: React.Ref<HTMLButtonElement>
 }
 
-const Button: React.FC<Props> = ({
-  component: Component = StyledButton,
-  onPress,
-  ...rest
-}) => {
-  const [startCoordinates, setStartCoordinates] = useState([0, 0])
+const Button = React.forwardRef<HTMLButtonElement, Props>(
+  ({ component: Component = StyledButton, onPress, ...rest }, ref) => {
+    const [startCoordinates, setStartCoordinates] = useState([0, 0])
 
-  const onTouchStart = (event: React.TouchEvent) => {
-    const { clientX, clientY } = event.touches[0]
-    setStartCoordinates([clientX, clientY])
-  }
-
-  const onTouchEnd = (event: React.TouchEvent) => {
-    const maxMove = 30
-    const { clientX, clientY } = event.changedTouches[0]
-    if (
-      Math.abs(startCoordinates[0] - clientX) < maxMove &&
-      Math.abs(startCoordinates[1] - clientY) < maxMove
-    ) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onPress(event as any)
-      event.preventDefault()
+    const onTouchStart = (event: React.TouchEvent) => {
+      const { clientX, clientY } = event.touches[0]
+      setStartCoordinates([clientX, clientY])
     }
-  }
 
-  return (
-    <Component
-      {...rest}
-      onTouchStart={onTouchStart}
-      onTouchEnd={onTouchEnd}
-      onClick={onPress}
-    />
-  )
-}
+    const onTouchEnd = (event: React.TouchEvent) => {
+      const maxMove = 30
+      const { clientX, clientY } = event.changedTouches[0]
+      if (
+        Math.abs(startCoordinates[0] - clientX) < maxMove &&
+        Math.abs(startCoordinates[1] - clientY) < maxMove
+      ) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onPress(event as any)
+        event.preventDefault()
+      }
+    }
+
+    return (
+      <Component
+        {...rest}
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+        onClick={onPress}
+        ref={ref}
+      />
+    )
+  }
+)
+
+Button.displayName = 'Button'
 
 export const SegmentedButton = styled.span`
   display: inline-flex;

--- a/src/components/ToggleTestModeButton.test.tsx
+++ b/src/components/ToggleTestModeButton.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
+import ToggleTestModeButton from './ToggleTestModeButton'
+
+test('shows a button to toggle to live mode when in test mode', async () => {
+  const { getByText } = render(
+    <ToggleTestModeButton
+      isTestMode
+      isTogglingTestMode={false}
+      toggleTestMode={jest.fn()}
+    />
+  )
+
+  getByText('Toggle to Live Mode')
+})
+
+test('shows a button to toggle to test mode when in live mode', async () => {
+  const { getByText } = render(
+    <ToggleTestModeButton
+      isTestMode={false}
+      isTogglingTestMode={false}
+      toggleTestMode={jest.fn()}
+    />
+  )
+
+  getByText('Toggle to Test Mode')
+})
+
+test('shows a disabled button with "Toggling" when toggling', async () => {
+  const { getByText } = render(
+    <ToggleTestModeButton
+      isTestMode
+      isTogglingTestMode
+      toggleTestMode={jest.fn()}
+    />
+  )
+
+  expect((getByText('Toggling…') as HTMLButtonElement).disabled).toBe(true)
+})
+
+test('calls the callback on confirmation', () => {
+  const toggleTestMode = jest.fn()
+  const { getByText, getAllByText } = render(
+    <ToggleTestModeButton
+      isTestMode
+      isTogglingTestMode={false}
+      toggleTestMode={toggleTestMode}
+    />
+  )
+
+  // Click the button.
+  fireEvent.click(getByText('Toggle to Live Mode'))
+
+  // Then click the confirmation button inside the modal.
+  const [confirmButton] = getAllByText('Toggle to Live Mode').filter(
+    (element) => element instanceof HTMLButtonElement && !element.disabled
+  )
+  expect(toggleTestMode).not.toHaveBeenCalled()
+  fireEvent.click(confirmButton)
+  expect(toggleTestMode).toHaveBeenCalled()
+})
+
+test('shows a modal when toggling to live mode', () => {
+  const toggleTestMode = jest.fn()
+  const { getByText } = render(
+    <ToggleTestModeButton
+      isTestMode
+      isTogglingTestMode
+      toggleTestMode={toggleTestMode}
+    />
+  )
+
+  getByText('Toggling to Live Mode')
+  getByText('Zeroing out scanned ballots and reloading…')
+})
+
+test('shows a modal when toggling to test mode', () => {
+  const toggleTestMode = jest.fn()
+  const { getByText } = render(
+    <ToggleTestModeButton
+      isTestMode={false}
+      isTogglingTestMode
+      toggleTestMode={toggleTestMode}
+    />
+  )
+
+  getByText('Toggling to Test Mode')
+  getByText('Zeroing out scanned ballots and reloading…')
+})

--- a/src/components/ToggleTestModeButton.tsx
+++ b/src/components/ToggleTestModeButton.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useRef, useState } from 'react'
+import Button from './Button'
+import Modal from './Modal'
+import Prose from './Prose'
+
+export interface Props {
+  isTestMode: boolean
+  isTogglingTestMode: boolean
+  toggleTestMode(): void
+}
+
+/**
+ * Presents a button to toggle between test & live modes with a confirmation.
+ */
+const ToggleTestModeButton: React.FC<Props> = ({
+  isTestMode,
+  isTogglingTestMode,
+  toggleTestMode,
+}) => {
+  const [isConfirming, setIsConfirming] = useState(isTogglingTestMode)
+  const defaultButtonRef = useRef<HTMLButtonElement>(null)
+
+  const toggleIsConfirming = useCallback(() => {
+    /* istanbul ignore else - just catches the case of clicking the overlay when toggling */
+    if (!isTogglingTestMode) {
+      setIsConfirming((prev) => !prev)
+    }
+  }, [isTogglingTestMode, setIsConfirming])
+
+  const focusDefaultButton = useCallback(() => {
+    defaultButtonRef.current?.focus()
+  }, [])
+
+  return (
+    <React.Fragment>
+      <Button
+        onPress={toggleIsConfirming}
+        disabled={isTogglingTestMode || isConfirming}
+      >
+        {isTogglingTestMode
+          ? 'Toggling…'
+          : isTestMode
+          ? 'Toggle to Live Mode'
+          : 'Toggle to Test Mode'}
+      </Button>
+      <Modal
+        isOpen={isConfirming}
+        centerContent
+        content={
+          <Prose textCenter>
+            <h1>
+              {isTogglingTestMode
+                ? isTestMode
+                  ? 'Toggling to Live Mode'
+                  : 'Toggling to Test Mode'
+                : isTestMode
+                ? 'Toggle to Live Mode'
+                : 'Toggle to Test Mode'}
+            </h1>
+            <p>
+              {isTogglingTestMode
+                ? 'Zeroing out scanned ballots and reloading…'
+                : 'Toggling test mode will zero out your scanned ballots. Are you sure?'}
+            </p>
+          </Prose>
+        }
+        actions={
+          !isTogglingTestMode && (
+            <React.Fragment>
+              <Button onPress={toggleIsConfirming}>Cancel</Button>
+              <Button ref={defaultButtonRef} primary onPress={toggleTestMode}>
+                {isTestMode ? 'Toggle to Live Mode' : 'Toggle to Test Mode'}
+              </Button>
+            </React.Fragment>
+          )
+        }
+        onOverlayClick={toggleIsConfirming}
+        onAfterOpen={focusDefaultButton}
+      />
+    </React.Fragment>
+  )
+}
+
+export default ToggleTestModeButton

--- a/src/screens/AdvancedOptionsScreen.test.tsx
+++ b/src/screens/AdvancedOptionsScreen.test.tsx
@@ -15,7 +15,7 @@ test('clicking "Export Backup…" shows progress', async () => {
         zeroData={jest.fn()}
         backup={backup}
         isTestMode={false}
-        togglingTestMode={false}
+        isTogglingTestMode={false}
         toggleTestMode={jest.fn()}
       />
     </Router>
@@ -54,7 +54,7 @@ test('backup error shows message', async () => {
         zeroData={jest.fn()}
         backup={backup}
         isTestMode={false}
-        togglingTestMode={false}
+        isTogglingTestMode={false}
         toggleTestMode={jest.fn()}
       />
     </Router>

--- a/src/screens/AdvancedOptionsScreen.tsx
+++ b/src/screens/AdvancedOptionsScreen.tsx
@@ -1,12 +1,12 @@
-import React, { useState, useCallback } from 'react'
-
+import React, { useCallback, useState } from 'react'
+import Button from '../components/Button'
+import LinkButton from '../components/LinkButton'
 import Main, { MainChild } from '../components/Main'
 import MainNav from '../components/MainNav'
-import Screen from '../components/Screen'
 import Modal from '../components/Modal'
 import Prose from '../components/Prose'
-import LinkButton from '../components/LinkButton'
-import Button from '../components/Button'
+import Screen from '../components/Screen'
+import ToggleTestModeButton from '../components/ToggleTestModeButton'
 
 interface Props {
   unconfigureServer: () => Promise<void>
@@ -14,7 +14,7 @@ interface Props {
   backup: () => Promise<void>
   hasBatches: boolean
   isTestMode: boolean
-  togglingTestMode: boolean
+  isTogglingTestMode: boolean
   toggleTestMode: () => Promise<void>
 }
 
@@ -24,7 +24,7 @@ const AdvancedOptionsScreen: React.FC<Props> = ({
   backup,
   hasBatches,
   isTestMode,
-  togglingTestMode,
+  isTogglingTestMode,
   toggleTestMode,
 }) => {
   const [isConfirmingFactoryReset, setIsConfirmingFactoryReset] = useState(
@@ -54,17 +54,13 @@ const AdvancedOptionsScreen: React.FC<Props> = ({
           <MainChild>
             <Prose>
               <h1>Advanced Options</h1>
-              {typeof isTestMode === 'boolean' && (
-                <p>
-                  <Button onPress={toggleTestMode} disabled={togglingTestMode}>
-                    {togglingTestMode
-                      ? 'Switching…'
-                      : isTestMode
-                      ? 'Toggle to Live Mode'
-                      : 'Toggle to Test Mode'}
-                  </Button>
-                </p>
-              )}
+              <p>
+                <ToggleTestModeButton
+                  isTestMode={isTestMode}
+                  isTogglingTestMode={isTogglingTestMode}
+                  toggleTestMode={toggleTestMode}
+                />
+              </p>
               <p>
                 <Button disabled={!hasBatches} onPress={toggleIsConfirmingZero}>
                   Delete Ballot Data…
@@ -84,7 +80,7 @@ const AdvancedOptionsScreen: React.FC<Props> = ({
             </Prose>
           </MainChild>
         </Main>
-        <MainNav>
+        <MainNav isTestMode={isTestMode}>
           <LinkButton small to="/">
             Back to Dashboard
           </LinkButton>


### PR DESCRIPTION
Rather than using a native `confirm` call, we now use a standard React modal. This allows us to provide better feedback and to block action until it's done toggling.

![test-mode-modal](https://user-images.githubusercontent.com/1938/97039127-c8fb9600-1520-11eb-9a7e-e75085da0ecf.gif)

cc @mattroe @mcchilders 